### PR TITLE
Ypiel/build docker image for all branches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,7 +65,7 @@ spec:
               passwordVariable: 'DOCKER_PASSWORD',
               usernameVariable: 'DOCKER_LOGIN')
           ]) {
-            sh "chmod +x ./connectors-se-docker/src/main/scripts/docker/*.sh && ./connectors-se-docker/src/main/scripts/docker/all.sh $(git rev-parse --abbrev-ref HEAD | tr / _)"
+            sh "chmod +x ./connectors-se-docker/src/main/scripts/docker/*.sh && ./connectors-se-docker/src/main/scripts/docker/all.sh `git rev-parse --abbrev-ref HEAD | tr / _`"
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,9 +57,6 @@ spec:
       }
     }
     stage('Build Docker Components Image') {
-      when {
-        expression { sh(returnStdout: true, script: 'git rev-parse --abbrev-ref HEAD').trim() == 'master' }
-      }
       steps {
         container('maven') {
           withCredentials([
@@ -68,7 +65,7 @@ spec:
               passwordVariable: 'DOCKER_PASSWORD',
               usernameVariable: 'DOCKER_LOGIN')
           ]) {
-            sh "chmod +x ./connectors-se-docker/src/main/scripts/docker/*.sh && ./connectors-se-docker/src/main/scripts/docker/all.sh"
+            sh "chmod +x ./connectors-se-docker/src/main/scripts/docker/*.sh && ./connectors-se-docker/src/main/scripts/docker/all.sh $(git rev-parse --abbrev-ref HEAD | tr / _)"
           }
         }
       }

--- a/connectors-se-docker/src/main/scripts/docker/all.sh
+++ b/connectors-se-docker/src/main/scripts/docker/all.sh
@@ -16,6 +16,6 @@
 #  limitations under the License.
 #
 
-. "$(dirname $0)/common.sh"
+. "$(dirname $0)/common.sh" $1
 . "$(dirname $0)/repository.sh"
 . "$(dirname $0)/server.sh"

--- a/connectors-se-docker/src/main/scripts/docker/common.sh
+++ b/connectors-se-docker/src/main/scripts/docker/common.sh
@@ -23,7 +23,12 @@ export CONNECTOR_VERSION=$(grep "<version>" "$BASEDIR/pom.xml" | head -n 1 | sed
 export TALEND_REGISTRY="${TALEND_REGISTRY:-registry.datapwn.com}"
 DOCKER_IMAGE_VERSION=${DOCKER_IMAGE_VERSION:-$CONNECTOR_VERSION}
 if [[ "$DOCKER_IMAGE_VERSION" = *"SNAPSHOT" ]]; then
-    DOCKER_IMAGE_VERSION=$(echo $CONNECTOR_VERSION | sed "s/-SNAPSHOT//")_$(date +%Y%m%d%I%M%S)
+
+    BRANCH="$1"
+    [ "master" = "$BRANCH" ] && BRANCH=""
+    [ -n "$BRANCH" ] && BRANCH=_${BRANCH}
+
+    DOCKER_IMAGE_VERSION=$(echo $CONNECTOR_VERSION | sed "s/-SNAPSHOT//")${BRANCH}_$(date +%Y%m%d%I%M%S)
 fi
 export DOCKER_IMAGE_VERSION
 

--- a/connectors-se-docker/src/main/scripts/docker/common.sh
+++ b/connectors-se-docker/src/main/scripts/docker/common.sh
@@ -23,11 +23,7 @@ export CONNECTOR_VERSION=$(grep "<version>" "$BASEDIR/pom.xml" | head -n 1 | sed
 export TALEND_REGISTRY="${TALEND_REGISTRY:-registry.datapwn.com}"
 DOCKER_IMAGE_VERSION=${DOCKER_IMAGE_VERSION:-$CONNECTOR_VERSION}
 if [[ "$DOCKER_IMAGE_VERSION" = *"SNAPSHOT" ]]; then
-
-    BRANCH="$1"
-    [ "master" = "$BRANCH" ] && BRANCH=""
-    [ -n "$BRANCH" ] && BRANCH=_${BRANCH}
-
+    BRANCH=_${1}
     DOCKER_IMAGE_VERSION=$(echo $CONNECTOR_VERSION | sed "s/-SNAPSHOT//")${BRANCH}_$(date +%Y%m%d%I%M%S)
 fi
 export DOCKER_IMAGE_VERSION


### PR DESCRIPTION
Docker image were only generated for master branch. Now it is for all and the name of the generated image contains the branch's name.

Here is first test in : https://ci-kube.datapwn.com/job/connectors-se/job/ypiel%252Fbuild_docker_image_for_all_branches/2/console

docker push registry.datapwn.com/talend/component-server-with-connectors-se:1.0.0_ypiel_build_docker_image_for_all_branches_20180808041734
