### PR TITLE
chore: Bump component runtime to 1.1.6. (#92)

### DIFF
--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -123,6 +123,7 @@
                     </argLine>
                     <systemPropertyVariables>
                         <talend.jdbc.it>${jdbc.it}</talend.jdbc.it>
+                        <talend.jdbc.it.oracle.skip>true</talend.jdbc.it.oracle.skip>
                         <talend.component.junit.handler.state>static</talend.component.junit.handler.state>
                         <!--
                            You can activate the targetParallelism to control the parallelism of the test pipeline.

--- a/jdbc/src/test/resources/testcontainers.properties
+++ b/jdbc/src/test/resources/testcontainers.properties
@@ -1,1 +1,1 @@
-oracle.container.image=wnameless/oracle-xe-11g@sha256:825ba799432809fc7200bb1d7ef954973a8991d7702a860c87177fe05301f7da
+#oracle.container.image=wnameless/oracle-xe-11g@sha256:825ba799432809fc7200bb1d7ef954973a8991d7702a860c87177fe05301f7da

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <component-api.version>1.1.4</component-api.version>
-    <component-runtime.version>1.1.5</component-runtime.version>
+    <component-runtime.version>1.1.6</component-runtime.version>
     <slf4j.version>1.7.25</slf4j.version>
 
     <beam.version>2.8.0</beam.version>


### PR DESCRIPTION
Merge integration branch for bumping tacokit version.

See https://github.com/Talend/connectors-se/pull/92