### PR TITLE
fix(TFD-7340): Rename sinks to Output for consistency.

### DIFF
--- a/jdbc/src/main/resources/org/talend/components/jdbc/output/Messages.properties
+++ b/jdbc/src/main/resources/org/talend/components/jdbc/output/Messages.properties
@@ -1,1 +1,1 @@
-Jdbc.Output._displayName=Database sink
+Jdbc.Output._displayName=Database Output


### PR DESCRIPTION
Related to TFD-7031 -- our vocabulary prefers "destination" to "sink".   I used "Output" to be consistent with every other component.