### PR TITLE
fix(TDI-42102): Use the derbyclient artifact.

### DIFF
--- a/jdbc/src/main/resources/TALEND-INF/local-configuration.properties
+++ b/jdbc/src/main/resources/TALEND-INF/local-configuration.properties
@@ -33,7 +33,7 @@ jdbc.drivers[0].paths[0]=mysql:mysql-connector-java:jar:8.0.13
 jdbc.drivers[1].id=Derby
 jdbc.drivers[1].order=100000
 jdbc.drivers[1].className=org.apache.derby.jdbc.ClientDriver
-jdbc.drivers[1].paths[0]=org.apache.derby:derby:jar:10.12.1.1
+jdbc.drivers[1].paths[0]=org.apache.derby:derbyclient:jar:10.12.1.1
 #
 # Oracle
 #


### PR DESCRIPTION
See https://jira.talendforge.org/browse/TDI-42102

The EmbeddedDriver class is in the derby artifact (present in config).

The ClientDriver class (present in config)  is in the derbyclient artifact.
