### PR TITLE
fix(TDI-42102): Disable Derby for all 1.0.2 remote engines.

### DIFF
--- a/jdbc/src/main/resources/TALEND-INF/local-configuration.properties
+++ b/jdbc/src/main/resources/TALEND-INF/local-configuration.properties
@@ -19,7 +19,7 @@ jdbc.supportedTableTypes[2]=SYNONYM
 #
 # Skipping drivers
 #
-jdbc.driver.derby.skip=false
+jdbc.driver.derby.skip=true
 #
 # MySQL
 #


### PR DESCRIPTION
I proposed a fix for TDI-42102 on master -- I'm not entirely sure it's the right thing to do, but we are certain that we don't want Derby database types on remote engines for Pipeline Designer (or Cloud Engine).  We can deactivate it in the 1.0.2 release and the change will be picked up before GA.

*_This is maintenance/1.0 only._*

For future releases, the component-server flag should be used.