### PR TITLE
fix(internal): bump lombok for building with Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.20</version>
+            <version>1.18.8</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Allow to build project with jdk>=10.