### PR TITLE
fix(TDI-43115): handle BYTES type in CouchbaseOuput

### DIFF
--- a/couchbase/src/main/java/org/talend/components/couchbase/output/CouchbaseOutput.java
+++ b/couchbase/src/main/java/org/talend/components/couchbase/output/CouchbaseOutput.java
@@ -17,7 +17,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -143,10 +142,7 @@ public class CouchbaseOutput implements Serializable {
         case LONG:
             return record.getLong(entryName);
         case BYTES:
-            byte[] bytes = record.getBytes(entryName);
-            Integer[] intArray = IntStream.range(0, bytes.length).map(i -> bytes[i]).boxed().collect(Collectors.toList())
-                    .toArray(new Integer[bytes.length]);
-            return JsonArray.from(intArray);
+            return com.couchbase.client.core.utils.Base64.encode(record.getBytes(entryName));
         case FLOAT:
             return Double.parseDouble(String.valueOf(record.getFloat(entryName)));
         case DOUBLE:
@@ -208,4 +204,5 @@ public class CouchbaseOutput implements Serializable {
         }
         return value;
     }
+
 }

--- a/couchbase/src/test/java/org/talend/components/couchbase/output/CouchbaseOutputTest.java
+++ b/couchbase/src/test/java/org/talend/components/couchbase/output/CouchbaseOutputTest.java
@@ -12,14 +12,10 @@
  */
 package org.talend.components.couchbase.output;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collector;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
@@ -320,15 +316,7 @@ public class CouchbaseOutputTest extends CouchbaseUtilTest {
         JsonObject jsonObject = jsonDoc.content();
         assertEquals(101, jsonObject.getInt("id"));
         assertEquals("kamikaze", jsonObject.getString("name"));
-        byte[] rbytes = jsonObject.getArray("byties").toList().stream().map(o1 -> (int) o1)
-                .collect(Collector.of(ByteArrayOutputStream::new, ByteArrayOutputStream::write, (baos1, baos2) -> {
-                    try {
-                        baos2.writeTo(baos1);
-                        return baos1;
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
-                    }
-                }, ByteArrayOutputStream::toByteArray));
+        byte[] rbytes = com.couchbase.client.core.utils.Base64.decode(jsonObject.getString("byties"));
         assertEquals(bytes.length, rbytes.length);
         assertEquals("aloha", new String(rbytes, Charset.defaultCharset()));
     }

--- a/couchbase/src/test/java/org/talend/components/couchbase/output/CouchbaseOutputTest.java
+++ b/couchbase/src/test/java/org/talend/components/couchbase/output/CouchbaseOutputTest.java
@@ -12,12 +12,16 @@
  */
 package org.talend.components.couchbase.output;
 
-import com.couchbase.client.deps.io.netty.util.ReferenceCountUtil;
-import com.couchbase.client.java.Bucket;
-import com.couchbase.client.java.document.BinaryDocument;
-import com.couchbase.client.java.document.JsonDocument;
-import com.couchbase.client.java.document.json.JsonObject;
-import lombok.extern.slf4j.Slf4j;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collector;
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,10 +39,13 @@ import org.talend.sdk.component.junit5.Injected;
 import org.talend.sdk.component.junit5.WithComponents;
 import org.talend.sdk.component.runtime.manager.chain.Job;
 
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Stream;
+import com.couchbase.client.deps.io.netty.util.ReferenceCountUtil;
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.document.BinaryDocument;
+import com.couchbase.client.java.document.JsonDocument;
+import com.couchbase.client.java.document.json.JsonObject;
+
+import lombok.extern.slf4j.Slf4j;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -228,13 +235,11 @@ public class CouchbaseOutputTest extends CouchbaseUtilTest {
         final Schema.Entry.Builder entryBuilder = recordBuilderFactory.newEntryBuilder();
         List<Record> records = new ArrayList<>();
         Record record1 = recordBuilderFactory.newRecordBuilder()
-                .withString(entryBuilder.withName("t_string").withType(Schema.Type.STRING).build(),
-                        generateDocId(idPrefix, 0))
+                .withString(entryBuilder.withName("t_string").withType(Schema.Type.STRING).build(), generateDocId(idPrefix, 0))
                 .withInt(entryBuilder.withName("t_int_min").withType(Schema.Type.INT).build(), 1971)
                 .withString(entryBuilder.withName("extra_content").withType(Schema.Type.STRING).build(), "path new").build();
         Record record2 = recordBuilderFactory.newRecordBuilder()
-                .withString(entryBuilder.withName("t_string").withType(Schema.Type.STRING).build(),
-                        generateDocId(idPrefix, 1))
+                .withString(entryBuilder.withName("t_string").withType(Schema.Type.STRING).build(), generateDocId(idPrefix, 1))
                 .withBoolean(entryBuilder.withName("t_boolean").withType(Schema.Type.BOOLEAN).build(), Boolean.FALSE)
                 .withString(entryBuilder.withName("extra_content2").withType(Schema.Type.STRING).build(), "path zap").build();
         records.add(record1);
@@ -302,4 +307,30 @@ public class CouchbaseOutputTest extends CouchbaseUtilTest {
         configuration.setDataSet(couchbaseDataSet);
         return configuration;
     }
+
+    @Test
+    void toJsonDocumentWithBytesType() {
+        byte[] bytes = "aloha".getBytes(Charset.defaultCharset());
+        String idValue = "fixBytes";
+        Record test = recordBuilderFactory.newRecordBuilder().withString("ID", idValue).withInt("id", 101)
+                .withString("name", "kamikaze").withBytes("byties", bytes).build();
+        CouchbaseOutput couch = new CouchbaseOutput(getOutputConfiguration(), null, null);
+        JsonDocument jsonDoc = couch.toJsonDocument("ID", test);
+        assertEquals(idValue, jsonDoc.id());
+        JsonObject jsonObject = jsonDoc.content();
+        assertEquals(101, jsonObject.getInt("id"));
+        assertEquals("kamikaze", jsonObject.getString("name"));
+        byte[] rbytes = jsonObject.getArray("byties").toList().stream().map(o1 -> (int) o1)
+                .collect(Collector.of(ByteArrayOutputStream::new, ByteArrayOutputStream::write, (baos1, baos2) -> {
+                    try {
+                        baos2.writeTo(baos1);
+                        return baos1;
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                }, ByteArrayOutputStream::toByteArray));
+        assertEquals(bytes.length, rbytes.length);
+        assertEquals("aloha", new String(rbytes, Charset.defaultCharset()));
+    }
+
 }


### PR DESCRIPTION
https://jira.talendforge.org/browse/TDI-43115 - handle BYTES type in CouchbaseOuput
BYTES type is not handed and throws an IllegalArgumentException. Add a default implementation that works in studio.