### PR TITLE
fix(TDI-43392): upgrade hadoop-commons version to 3.2.1

### DIFF
--- a/azure-dls-gen2/pom.xml
+++ b/azure-dls-gen2/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <commons-csv.version>1.7.1</commons-csv.version>
         <parquet.version>1.10.1</parquet.version>
-        <hadoop-common.version>2.8.2</hadoop-common.version>
+        <hadoop-common.version>3.2.1</hadoop-common.version>
         <hamcrest.version>1.3</hamcrest.version>
     </properties>
 

--- a/azure-dls-gen2/pom.xml
+++ b/azure-dls-gen2/pom.xml
@@ -64,6 +64,22 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-util</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-servlet</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-webapp</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/azure-dls-gen2/src/main/java/org/talend/components/adlsgen2/common/format/csv/CsvConfiguration.java
+++ b/azure-dls-gen2/src/main/java/org/talend/components/adlsgen2/common/format/csv/CsvConfiguration.java
@@ -19,7 +19,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.talend.components.adlsgen2.common.format.FileEncoding;
 import org.talend.components.adlsgen2.runtime.AdlsGen2RuntimeException;
 import org.talend.sdk.component.api.configuration.Option;

--- a/azure-dls-gen2/src/main/java/org/talend/components/adlsgen2/common/format/csv/CsvConverter.java
+++ b/azure-dls-gen2/src/main/java/org/talend/components/adlsgen2/common/format/csv/CsvConverter.java
@@ -21,7 +21,7 @@ import java.util.Set;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.csv.QuoteMode;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.talend.components.adlsgen2.common.converter.RecordConverter;
 import org.talend.sdk.component.api.record.Record;
 import org.talend.sdk.component.api.record.Schema;

--- a/azure-dls-gen2/src/main/java/org/talend/components/adlsgen2/runtime/formatter/CsvContentFormatter.java
+++ b/azure-dls-gen2/src/main/java/org/talend/components/adlsgen2/runtime/formatter/CsvContentFormatter.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.talend.components.adlsgen2.common.format.csv.CsvConfiguration;
 import org.talend.components.adlsgen2.common.format.csv.CsvConverter;
 import org.talend.components.adlsgen2.output.OutputConfiguration;

--- a/azure-dls-gen2/src/main/java/org/talend/components/adlsgen2/service/AdlsGen2Service.java
+++ b/azure-dls-gen2/src/main/java/org/talend/components/adlsgen2/service/AdlsGen2Service.java
@@ -31,7 +31,7 @@ import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 import javax.json.JsonValue;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.talend.components.adlsgen2.common.format.avro.AvroIterator;
 import org.talend.components.adlsgen2.common.format.csv.CsvIterator;
 import org.talend.components.adlsgen2.common.format.json.JsonIterator;


### PR DESCRIPTION
https://jira.talendforge.org/browse/TDI-43392

Upgrade hadoop-commons library version to the latest version. 3.2.1 (https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-common/3.2.1)
Fix compile errors.