### PR TITLE
fix(TDI-44020): add spaces before and after

### DIFF
--- a/jdbc/src/main/java/org/talend/components/jdbc/output/statement/operations/snowflake/SnowflakeDelete.java
+++ b/jdbc/src/main/java/org/talend/components/jdbc/output/statement/operations/snowflake/SnowflakeDelete.java
@@ -52,7 +52,7 @@ public class SnowflakeDelete extends Delete {
                 try (final Statement statement = connection.createStatement()) {
                     statement.execute("delete from " + fqTableName + " target using " + fqTmpTableName + " as source where "
                             + getConfiguration().getKeys().stream().map(key -> getPlatform().identifier(key))
-                                    .map(key -> "source." + key + "= target." + key).collect(joining("AND", " ", " ")));
+                                    .map(key -> "source." + key + "= target." + key).collect(joining(" AND ")));
                 }
             }
             connection.commit();


### PR DESCRIPTION
https://jira.talendforge.org/browse/TDI-44020

Delete statement is generated without spaces between operation keys.

Fix joining of several operation keys