### PR TITLE
feat(TDI-44119): CosmosDB support of jsonToRecord number type option

### DIFF
--- a/cosmosDB/src/main/java/org/talend/components/cosmosDB/input/CosmosDBInput.java
+++ b/cosmosDB/src/main/java/org/talend/components/cosmosDB/input/CosmosDBInput.java
@@ -59,7 +59,7 @@ public class CosmosDBInput implements Serializable {
         this.service = service;
         this.builderFactory = builderFactory;
         this.i18n = i18n;
-        this.jsonToRecord = new JsonToRecord(builderFactory);
+        this.jsonToRecord = new JsonToRecord(builderFactory, configuration.isJsonForceDouble());
     }
 
     @PostConstruct

--- a/cosmosDB/src/main/java/org/talend/components/cosmosDB/input/CosmosDBInputConfiguration.java
+++ b/cosmosDB/src/main/java/org/talend/components/cosmosDB/input/CosmosDBInputConfiguration.java
@@ -16,6 +16,7 @@ import lombok.Data;
 import org.talend.components.cosmosDB.dataset.QueryDataset;
 import org.talend.sdk.component.api.component.Version;
 import org.talend.sdk.component.api.configuration.Option;
+import org.talend.sdk.component.api.configuration.ui.DefaultValue;
 import org.talend.sdk.component.api.configuration.ui.layout.GridLayout;
 import org.talend.sdk.component.api.configuration.ui.layout.GridLayouts;
 import org.talend.sdk.component.api.meta.Documentation;
@@ -25,12 +26,18 @@ import java.io.Serializable;
 @Version(1)
 @Data
 @GridLayouts({ @GridLayout({ @GridLayout.Row({ "dataset" }), //
-        }), @GridLayout(names = GridLayout.FormType.ADVANCED, value = { @GridLayout.Row({ "dataset" }) }) })
+        }), @GridLayout(names = GridLayout.FormType.ADVANCED, value = { @GridLayout.Row({ "dataset" }),
+                @GridLayout.Row({ "jsonForceDouble" }) }) })
 @Documentation("cosmosDB input Mapper Configuration")
 public class CosmosDBInputConfiguration implements Serializable {
 
     @Option
     @Documentation("dataset")
     private QueryDataset dataset;
+
+    @Option
+    @DefaultValue("true")
+    @Documentation("Force json number to double.")
+    private boolean jsonForceDouble = true;
 
 }

--- a/cosmosDB/src/main/resources/org/talend/components/cosmosDB/input/Messages.properties
+++ b/cosmosDB/src/main/resources/org/talend/components/cosmosDB/input/Messages.properties
@@ -1,2 +1,5 @@
 CosmosDB.SQLAPIInput._displayName = CosmosDBSQLAPIInput
 CosmosDBInputConfiguration.dataset._displayName = Dataset
+
+CosmosDBInputConfiguration.jsonForceDouble._displayName = Infer all numbers as double.
+CosmosDBInputConfiguration.jsonForceDouble._placeholder =


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDI-44119
CosmosDB cannot transfer array with Integer and Double values.

**What is the new behavior?**
JsonToRecord now support an option to infer number type of force them to double, it has to be used by connectors. Need to be supported by CosmosDB

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


