### PR TITLE
Use root locales validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,7 @@
         <!-- should enforcing rules fail? Not yet, but soon! -->
         <enforcer.fail>false</enforcer.fail>
         <!-- component-runtime validations -->
+	<talend.validation.locale>root</talend.validation.locale>
         <validation.model>true</validation.model>
         <validation.placeholder>false</validation.placeholder>
         <validation.documentation>true</validation.documentation>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <!-- should enforcing rules fail? Not yet, but soon! -->
         <enforcer.fail>false</enforcer.fail>
         <!-- component-runtime validations -->
-	<talend.validation.locale>root</talend.validation.locale>
+        <talend.validation.locale>root</talend.validation.locale>
         <validation.model>true</validation.model>
         <validation.placeholder>false</validation.placeholder>
         <validation.documentation>true</validation.documentation>


### PR DESCRIPTION
We can't remove I18n method since it make the build fail because locales _EN is use for validation.