### PR TITLE
fix(TFD-11651): add the epoll native 4.1.48-Final to pubsub component

### DIFF
--- a/pubsub/pom.xml
+++ b/pubsub/pom.xml
@@ -42,6 +42,11 @@
             <version>2.0.26.Final</version>
         </dependency>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <version>4.1.48.Final</version>
+        </dependency>
+        <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-core-asl</artifactId>
         </dependency>
@@ -70,6 +75,7 @@
             <groupId>org.talend.components</groupId>
             <artifactId>connectors-test-bom</artifactId>
             <type>pom</type>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>


### PR DESCRIPTION
A wrong version of this epoll dependency was used in grpc-netty, and it led to class cast exception. See the JIRA comment for more details.