### PR TITLE
TDI-45519 : jacoco

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -808,6 +808,10 @@
             <goals>
               <goal>prepare-agent</goal>
             </goals>
+            <configuration>
+              <destFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</destFile>
+              <append>true</append>
+            </configuration>
           </execution>
           <execution>
             <id>post-unit-test</id>
@@ -816,8 +820,7 @@
               <goal>report</goal>
             </goals>
             <configuration>
-              <dataFile>${project.build.directory}/jacoco.exec</dataFile>
-              <outputDirectory>${project.build.directory}/jacoco-ut</outputDirectory>
+              <dataFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</dataFile>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TDI-45519

Jacoco plugin update on pom.xml to work near as on connectors-ee

[Jenkins log](https://jenkins-connectors.datapwn.com/job/connectors%20ee/job/build/job/master/314/consoleFull) don't contains warning anymore.