### PR TITLE
feat(TDI-45574): bump component-runtime to 1.29.1

### DIFF
--- a/common-stream-io/stream-line/src/test/java/org/talend/components/common/stream/output/line/LineValueBuilder.java
+++ b/common-stream-io/stream-line/src/test/java/org/talend/components/common/stream/output/line/LineValueBuilder.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright (C) 2006-2021 Talend Inc. - www.talend.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package org.talend.components.common.stream.output.line;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -36,15 +48,12 @@ public class LineValueBuilder implements AssertionsBuilder<List<String>> {
                     this.addField(id, subField, subValue);
                 }
             }
-        }
-        else if (value == null) {
+        } else if (value == null) {
             this.fields.add(null);
-        }
-        else if (field.getType() == Schema.Type.BYTES) {
+        } else if (field.getType() == Schema.Type.BYTES) {
             final String lineValue = new String(Base64.getEncoder().encode((byte[]) value));
             this.fields.add(lineValue);
-        }
-        else {
+        } else {
             this.fields.add(value.toString());
         }
     }

--- a/common-stream-io/stream-line/src/test/java/org/talend/components/common/stream/output/line/RecordSerializerLineHelperTest.java
+++ b/common-stream-io/stream-line/src/test/java/org/talend/components/common/stream/output/line/RecordSerializerLineHelperTest.java
@@ -108,7 +108,6 @@ class RecordSerializerLineHelperTest {
                 .build();
     }
 
-
     @ParameterizedTest
     @MethodSource("testDataLine")
     void testRecordsLine(DataSet<List<String>> ds) {
@@ -116,12 +115,10 @@ class RecordSerializerLineHelperTest {
         ds.check(values);
     }
 
-
     private static Iterator<DataSet<List<String>>> testDataLine() {
         final AssertionsBuilder<List<String>> valueBuilder = new LineValueBuilder();
         final RecordBuilderFactory factory = new RecordBuilderFactoryImpl("test");
-        final DatasetGenerator<List<String>> generator = new DatasetGenerator<>(factory,
-                valueBuilder);
+        final DatasetGenerator<List<String>> generator = new DatasetGenerator<>(factory, valueBuilder);
         return generator.generate(40);
     }
 

--- a/marketo/src/test/java/org/talend/components/marketo/MarketoBaseTestIT.java
+++ b/marketo/src/test/java/org/talend/components/marketo/MarketoBaseTestIT.java
@@ -37,13 +37,11 @@ import lombok.Data;
 @WithComponents("org.talend.components.marketo")
 public class MarketoBaseTestIT extends MarketoBaseTest {
 
-
     @DecryptedServer(value = "marketo-nocrm")
     protected Server serverNoCrm;
 
     @DecryptedServer(value = "marketo-nocrm-instance")
     protected Server serverNoCrmInstance;
-
 
     @BeforeClass
     void init() {

--- a/marketo/src/test/java/org/talend/components/marketo/dataset/MarketoInputConfigurationTest.java
+++ b/marketo/src/test/java/org/talend/components/marketo/dataset/MarketoInputConfigurationTest.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright (C) 2006-2021 Talend Inc. - www.talend.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package org.talend.components.marketo.dataset;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -17,7 +29,6 @@ import org.talend.components.marketo.dataset.MarketoDataSet.LeadAction;
 import org.talend.components.marketo.datastore.MarketoDataStore;
 
 class MarketoInputConfigurationTest {
-
 
     @Test
     void serial() throws IOException, ClassNotFoundException {

--- a/marketo/src/test/java/org/talend/components/marketo/datastore/MarketoDataStoreTest.java
+++ b/marketo/src/test/java/org/talend/components/marketo/datastore/MarketoDataStoreTest.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright (C) 2006-2021 Talend Inc. - www.talend.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package org.talend.components.marketo.datastore;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/marketo/src/test/java/org/talend/components/marketo/input/LeadSourceTest.java
+++ b/marketo/src/test/java/org/talend/components/marketo/input/LeadSourceTest.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright (C) 2006-2021 Talend Inc. - www.talend.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package org.talend.components.marketo.input;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -48,7 +60,6 @@ class LeadSourceTest extends MarketoBaseTest {
 
         this.dataSet.setDateTimeMode(DateTimeMode.absolute);
         this.dataSet.setSinceDateTimeAbsolute("2019-03-23");
-
 
         this.dataSet.setActivityTypeIds(Arrays.asList("1", "2", "3", "6", "7", "8", "9", "10", "22"));
         this.dataSet.setLeadAction(LeadAction.getLeadActivity);

--- a/marketo/src/test/java/org/talend/components/marketo/service/UIActionServiceTestIT.java
+++ b/marketo/src/test/java/org/talend/components/marketo/service/UIActionServiceTestIT.java
@@ -37,11 +37,8 @@ import lombok.extern.slf4j.Slf4j;
 @WithComponents("org.talend.components.marketo")
 public class UIActionServiceTestIT extends MarketoBaseTestIT {
 
-
-
     @Service
     protected UIActionService service;
-
 
     @Test
     void getListNamesExceedingBatchLimit() {

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     </license>
   </licenses>
 
-    <modules>
+  <modules>
         <module>jdbc</module>
         <module>salesforce</module>
         <module>mongodb</module>
@@ -85,7 +85,7 @@
 
     <locales.version>[1.18,)</locales.version>
 
-    <component-runtime.version>1.28.0</component-runtime.version>
+    <component-runtime.version>1.29.1</component-runtime.version>
     <slf4j.version>1.7.28</slf4j.version>
     <log4j-api.version>2.14.0</log4j-api.version>
     <beanutils.version>1.9.4</beanutils.version>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TDI-45574

Also, fixed some code formatting and missing licenses.

*Related PR*
- https://github.com/Talend/connectors-se/pull/547
- https://github.com/Talend/connectors-ee/pull/115
- https://github.com/Talend/cloud-components/pull/541
