### PR TITLE
TDI-46001 : generated filename keep extension

### DIFF
--- a/google-storage/src/main/java/org/talend/components/google/storage/service/BlobNameBuilder.java
+++ b/google-storage/src/main/java/org/talend/components/google/storage/service/BlobNameBuilder.java
@@ -26,23 +26,54 @@ public class BlobNameBuilder implements Serializable {
 
     private static final int UUID_STRING_SIZE = 36;
 
-    public String generateName(final String begin) {
-        return begin + '_' + UUID.randomUUID().toString();
+    public String generateName(final String originalName) {
+        final int extensionStart = originalName.lastIndexOf('.');
+
+        final String generatedName;
+        if (extensionStart < 0) {
+            generatedName = originalName + '_' + UUID.randomUUID();
+        } else {
+            generatedName = originalName.substring(0, extensionStart) + '_' + UUID.randomUUID()
+                    + originalName.substring(extensionStart);
+        }
+        return generatedName;
     }
 
     public boolean isGenerated(final String begin, final String name) {
-        return name.startsWith(begin + '_') && name.length() == begin.length() + 1 + UUID_STRING_SIZE
-                && this.isUUID(name.substring(begin.length() + 1));
+
+        final int extensionPos = this.lastOrLength(begin, '.');
+
+        final String start = begin.substring(0, extensionPos);
+        final String extension = begin.substring(extensionPos);
+
+        return name.startsWith(start + '_') //
+                && name.length() == begin.length() + 1 + UUID_STRING_SIZE //
+                && this.isUUID(name.substring(start.length() + 1, name.length() - extension.length())); //
     }
 
-    public String revert(String generatedName) {
-        if (generatedName != null) {
-            int separatorPos = generatedName.lastIndexOf('_');
-            if (separatorPos >= 0 && this.isUUID(generatedName.substring(separatorPos + 1))) {
-                return generatedName.substring(0, separatorPos);
-            }
+    public String revert(final String generatedName) {
+        if (generatedName == null) {
+            return null;
         }
-        return generatedName;
+        final int extensionPos = this.lastOrLength(generatedName, '.');
+
+        int separatorPos = generatedName.lastIndexOf('_', extensionPos);
+        if (separatorPos < 0) {
+            return generatedName;
+        }
+        final String uuidCandidate = generatedName.substring(separatorPos + 1, extensionPos);
+        if (!this.isUUID(uuidCandidate)) {
+            return generatedName;
+        }
+
+        final String revertedName = generatedName.substring(0, separatorPos) + generatedName.substring(extensionPos);
+
+        return revertedName;
+    }
+
+    private int lastOrLength(String name, char element) {
+        final int pos = name.lastIndexOf(element);
+        return pos < 0 ? name.length() : pos;
     }
 
     private boolean isUUID(final String uuidString) {

--- a/google-storage/src/main/java/org/talend/components/google/storage/service/StorageImpl.java
+++ b/google-storage/src/main/java/org/talend/components/google/storage/service/StorageImpl.java
@@ -85,13 +85,27 @@ public class StorageImpl implements StorageFacade {
 
     @Override
     public Stream<String> findBlobsName(final String bucket, final String blobStartName) {
-        final BlobListOption blobListOption = Storage.BlobListOption.prefix(blobStartName);
+        final BlobListOption blobListOption = Storage.BlobListOption.prefix(basename(blobStartName));
         final Page<Blob> blobPage = this.getStorage().list(bucket, blobListOption);
 
         return StreamSupport.stream(blobPage.iterateAll().spliterator(), false) //
                 .map(Blob::getName) //
                 .filter((String name) -> Objects.equals(blobStartName, name)
                         || this.nameBuilder.isGenerated(blobStartName, name));
+    }
+
+    /**
+     * Return name without extension if any.
+     * 
+     * @param name : name (xx; xx.csv)
+     * @return name without extension (xx).
+     */
+    private String basename(final String name) {
+        final int posSep = name.lastIndexOf('.');
+        if (posSep < 0) {
+            return name;
+        }
+        return name.substring(0, posSep);
     }
 
     @Override

--- a/google-storage/src/test/java/org/talend/components/google/storage/service/BlobNameBuilderTest.java
+++ b/google-storage/src/test/java/org/talend/components/google/storage/service/BlobNameBuilderTest.java
@@ -12,8 +12,15 @@
  */
 package org.talend.components.google.storage.service;
 
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class BlobNameBuilderTest {
 
@@ -37,5 +44,23 @@ class BlobNameBuilderTest {
                 builder.revert("Hello_1234567890ABCDEF1234567890ABCDEF1234"));
 
         Assertions.assertEquals("Hello", builder.revert(builder.generateName("Hello")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideNames")
+    void generateNameWithExtension(final String input, final String pattern) {
+        final BlobNameBuilder builder = new BlobNameBuilder();
+        final String generateName = builder.generateName(input);
+        Assertions.assertTrue(generateName.matches(pattern),
+                "Wrong generated name '" + generateName + "'" + " for '" + input + "'");
+        Assertions.assertTrue(builder.isGenerated(input, generateName));
+
+        Assertions.assertEquals(input, builder.revert(generateName));
+    }
+
+    private static Stream<Arguments> provideNames() {
+        return Stream.of(Arguments.of("Hello.csv", "^Hello_[0-9a-f\\-]{36}\\.csv$"),
+                Arguments.of("Hello._", "^Hello_[0-9a-f\\-]{36}\\._$"), Arguments.of("Hello.", "^Hello_[0-9a-f\\-]{36}\\.$"),
+                Arguments.of("Hello", "^Hello_[0-9a-f\\-]{36}$"));
     }
 }

--- a/google-storage/src/test/java/org/talend/components/google/storage/service/BlobNameBuilderTest.java
+++ b/google-storage/src/test/java/org/talend/components/google/storage/service/BlobNameBuilderTest.java
@@ -61,11 +61,10 @@ class BlobNameBuilderTest {
     private static Stream<Arguments> provideNames() {
         return Stream.of( //
                 Arguments.of("Hello.csv", "^Hello_[0-9a-f\\-]{36}\\.csv$"), //
-                Arguments.of("Hello._", "^Hello_[0-9a-f\\-]{36}\\._$"),  //
+                Arguments.of("Hello._", "^Hello_[0-9a-f\\-]{36}\\._$"), //
                 Arguments.of("Hello.", "^Hello_[0-9a-f\\-]{36}\\.$"), //
                 Arguments.of("Hello", "^Hello_[0-9a-f\\-]{36}$"), //
                 Arguments.of(".gitignore", "^_[0-9a-f\\-]{36}\\.gitignore$"), //
-                Arguments.of(".", "^_[0-9a-f\\-]{36}\\.$")
-                );
+                Arguments.of(".", "^_[0-9a-f\\-]{36}\\.$"));
     }
 }

--- a/google-storage/src/test/java/org/talend/components/google/storage/service/BlobNameBuilderTest.java
+++ b/google-storage/src/test/java/org/talend/components/google/storage/service/BlobNameBuilderTest.java
@@ -59,8 +59,13 @@ class BlobNameBuilderTest {
     }
 
     private static Stream<Arguments> provideNames() {
-        return Stream.of(Arguments.of("Hello.csv", "^Hello_[0-9a-f\\-]{36}\\.csv$"),
-                Arguments.of("Hello._", "^Hello_[0-9a-f\\-]{36}\\._$"), Arguments.of("Hello.", "^Hello_[0-9a-f\\-]{36}\\.$"),
-                Arguments.of("Hello", "^Hello_[0-9a-f\\-]{36}$"));
+        return Stream.of( //
+                Arguments.of("Hello.csv", "^Hello_[0-9a-f\\-]{36}\\.csv$"), //
+                Arguments.of("Hello._", "^Hello_[0-9a-f\\-]{36}\\._$"),  //
+                Arguments.of("Hello.", "^Hello_[0-9a-f\\-]{36}\\.$"), //
+                Arguments.of("Hello", "^Hello_[0-9a-f\\-]{36}$"), //
+                Arguments.of(".gitignore", "^_[0-9a-f\\-]{36}\\.gitignore$"), //
+                Arguments.of(".", "^_[0-9a-f\\-]{36}\\.$")
+                );
     }
 }

--- a/google-storage/src/test/java/org/talend/components/google/storage/service/StorageImplTest.java
+++ b/google-storage/src/test/java/org/talend/components/google/storage/service/StorageImplTest.java
@@ -123,6 +123,30 @@ class StorageImplTest {
         blobsName.stream().allMatch((String n) -> builder.isGenerated("blob", n));
     }
 
+    @Test
+    void findBlobsNameWithExtension() throws IOException {
+        final GSDataStore dataStore = buildDataStore();
+        final StorageImpl st = new StorageImpl(this.credentialService, dataStore.getJsonCredentials(), i18n);
+
+        final BlobNameBuilder builder = new BlobNameBuilder();
+        final String b1 = builder.generateName("blob.csv");
+        final String b2 = builder.generateName("blob.csv");
+        final String b3 = builder.generateName("blob.csv");
+        final String b4 = builder.generateName("blob.cs");
+        final String b5 = builder.generateName("blob");
+
+        this.storeContent("bucket", b1, "Hello");
+        this.storeContent("bucket", b2, "Bonjour");
+        this.storeContent("bucket", b3, "Pryvit");
+        this.storeContent("bucket", b4, "Wrong");
+        this.storeContent("bucket", b5, "Wrong2");
+
+        final List<String> blobsName = st.findBlobsName("bucket", "blob.csv") //
+                .collect(Collectors.toList());
+        Assertions.assertEquals(3, blobsName.size());
+        blobsName.stream().allMatch((String n) -> builder.isGenerated("blob", n));
+    }
+
     private String getContentFile(String relativePath) throws IOException {
         final URL urlJWT = Thread.currentThread().getContextClassLoader().getResource(relativePath);
 


### PR DESCRIPTION
https://jira.talendforge.org/browse/TDI-46001

generated google storage file name should keep extension.
(dummy.txt => dummy_<uuid>.txt; instead of dummy.txt_<uuid>)