### PR TITLE
fix(TDI-45981): NetSuite2019Input requires commons-lang3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <jacoco.version>0.8.2</jacoco.version>
 
     <commons-csv.version>1.4</commons-csv.version>
-    <commons-lang3.version>3.9</commons-lang3.version>
+    <commons-lang3.version>3.10</commons-lang3.version>
     <httpclient.version>4.5.13</httpclient.version>
     <httpcore.version>4.4.12</httpcore.version>
     <compress.version>1.19</compress.version>


### PR DESCRIPTION
* updated commons-lang3 version to 3.10