### PR TITLE
chore(TDI-46098): bump httpcore to 4.4.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
     <commons-csv.version>1.4</commons-csv.version>
     <commons-lang3.version>3.10</commons-lang3.version>
     <httpclient.version>4.5.13</httpclient.version>
-    <httpcore.version>4.4.12</httpcore.version>
+    <httpcore.version>4.4.13</httpcore.version> <!-- update this with httpclient -->
     <compress.version>1.19</compress.version>
     <commons-codec.version>1.14</commons-codec.version>
     <mockito.version>1.10.19</mockito.version>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TDI-46098
* the same version as httpclient 4.5.13 use
https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient/4.5.13

Related
https://github.com/Talend/connectors-ee/pull/310
https://github.com/Talend/cloud-components/pull/629