### PR TITLE
fix(TDI-46715): Check Jdbc input query is one single query

### DIFF
--- a/jdbc/src/main/java/org/talend/components/jdbc/input/AbstractInputEmitter.java
+++ b/jdbc/src/main/java/org/talend/components/jdbc/input/AbstractInputEmitter.java
@@ -73,7 +73,10 @@ public abstract class AbstractInputEmitter implements Serializable {
         if (query == null || query.trim().isEmpty()) {
             throw new IllegalArgumentException(i18n.errorEmptyQuery());
         }
-        if (jdbcDriversService.isNotReadOnlySQLQuery(query)) {
+        if (jdbcDriversService.isNotReadOnlySQLQuery(query) || query.contains(";")) {
+            // We don't want to authorize queries containing ";", because by chaining queries,
+            // a user could perform non readonly operations like dropping a table.
+            // Currently, the check in JdbcService overlook this use case.
             throw new IllegalArgumentException(i18n.errorUnauthorizedQuery());
         }
 


### PR DESCRIPTION
As explained in https://jira.talendforge.org/browse/TDI-46715, 
When a user create a dataset using jdbc connection and an input query,
he can chain queries in a one-liner using the `;` separator.
Doing so, the read-only check is bypassed and a user can performed non readonly operations.

This fix is a quick/dirty fix, there are certainly more uncovered use cases and we can't find them all using regexes.
However the new SQL compiler of Processing Runtime will be using a SQL parser (Apache Calcite), therefore a better solution might be found then.