### PR TITLE
Hackathon(TPX): Improve the perfomance of JdbcService

### DIFF
--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>jdbc</artifactId>
+    <version>1.27.7</version>
 
     <name>Connectors SE :: JDBC</name>
     <description>Suite of JDBC component</description>

--- a/jdbc/src/main/java/org/talend/components/jdbc/input/AbstractInputEmitter.java
+++ b/jdbc/src/main/java/org/talend/components/jdbc/input/AbstractInputEmitter.java
@@ -53,6 +53,8 @@ public abstract class AbstractInputEmitter implements Serializable {
 
     private ResultSet resultSet;
 
+    private ResultSetMetaData metaData;
+
     private JdbcService.JdbcDatasource dataSource;
 
     private transient Schema schema;
@@ -83,6 +85,7 @@ public abstract class AbstractInputEmitter implements Serializable {
             statement = connection.createStatement();
             statement.setFetchSize(inputConfig.getDataSet().getFetchSize());
             resultSet = statement.executeQuery(query);
+            metaData = new CachedResultSetMetaData(resultSet.getMetaData());
         } catch (final SQLException e) {
             throw toIllegalStateException(e);
         }
@@ -94,11 +97,9 @@ public abstract class AbstractInputEmitter implements Serializable {
             if (!resultSet.next()) {
                 return null;
             }
-
-            log.info("Hello from optimized version!!");
-            final ResultSetMetaData metaData = new CachedResultSetMetaData(resultSet.getMetaData());
             // final ResultSetMetaData metaData = resultSet.getMetaData();
             if (schema == null) {
+                log.info("Hello from optimized version!!");
                 final Schema.Builder schemaBuilder = recordBuilderFactory.newSchemaBuilder(RECORD);
                 IntStream
                         .rangeClosed(1, metaData.getColumnCount())

--- a/jdbc/src/main/java/org/talend/components/jdbc/input/AbstractInputEmitter.java
+++ b/jdbc/src/main/java/org/talend/components/jdbc/input/AbstractInputEmitter.java
@@ -95,7 +95,9 @@ public abstract class AbstractInputEmitter implements Serializable {
                 return null;
             }
 
-            final ResultSetMetaData metaData = resultSet.getMetaData();
+            log.info("Hello from optimized version!!");
+            final ResultSetMetaData metaData = new CachedResultSetMetaData(resultSet.getMetaData());
+            // final ResultSetMetaData metaData = resultSet.getMetaData();
             if (schema == null) {
                 final Schema.Builder schemaBuilder = recordBuilderFactory.newSchemaBuilder(RECORD);
                 IntStream

--- a/jdbc/src/main/java/org/talend/components/jdbc/input/CachedResultSetMetaData.java
+++ b/jdbc/src/main/java/org/talend/components/jdbc/input/CachedResultSetMetaData.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2006-2021 Talend Inc. - www.talend.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.talend.components.jdbc.input;
+
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CachedResultSetMetaData implements ResultSetMetaData {
+
+    final ResultSetMetaData metaData;
+
+    private final Map<Integer, Integer> ct = new HashMap<>();
+
+    private final Map<Integer, Integer> mp = new HashMap<>();
+
+    private final Map<Integer, String> cn = new HashMap<>();
+
+    @Override
+    public String toString() {
+        return ct.toString() + mp.toString() + cn.toString();
+    }
+
+    @Override
+    public int getColumnCount() throws SQLException {
+        return metaData.getColumnCount();
+    }
+
+    @Override
+    public boolean isAutoIncrement(int column) throws SQLException {
+        throw new IllegalArgumentException();
+    }
+
+    @Override
+    public boolean isCaseSensitive(int column) throws SQLException {
+        throw new IllegalArgumentException();
+    }
+
+    @Override
+    public boolean isSearchable(int column) throws SQLException {
+        throw new IllegalArgumentException();
+    }
+
+    @Override
+    public boolean isCurrency(int column) throws SQLException {
+        throw new IllegalArgumentException();
+    }
+
+    @Override
+    public int isNullable(int column) throws SQLException {
+        return mp.computeIfAbsent(column, c -> {
+            try {
+                return metaData.isNullable(c);
+            } catch (SQLException e) {
+                throw new IllegalArgumentException(e);
+            }
+        });
+    }
+
+    @Override
+    public boolean isSigned(int column) throws SQLException {
+        throw new IllegalArgumentException();
+    }
+
+    @Override
+    public int getColumnDisplaySize(int column) throws SQLException {
+        throw new IllegalArgumentException();
+    }
+
+    @Override
+    public String getColumnLabel(int column) throws SQLException {
+        throw new IllegalArgumentException();
+    }
+
+    @Override
+    public String getColumnName(int column) throws SQLException {
+        return cn.computeIfAbsent(column, c -> {
+            try {
+                return metaData.getColumnName(c);
+            } catch (SQLException e) {
+                throw new IllegalArgumentException(e);
+            }
+        });
+    }
+
+    @Override
+    public String getSchemaName(int column) throws SQLException {
+        throw new IllegalArgumentException();
+    }
+
+    @Override
+    public int getPrecision(int column) throws SQLException {
+        throw new IllegalArgumentException();
+    }
+
+    @Override
+    public int getScale(int column) throws SQLException {
+        throw new IllegalArgumentException();
+    }
+
+    @Override
+    public String getTableName(int column) throws SQLException {
+        throw new IllegalArgumentException();
+    }
+
+    @Override
+    public String getCatalogName(int column) throws SQLException {
+        throw new IllegalArgumentException();
+    }
+
+    @Override
+    public int getColumnType(int column) throws SQLException {
+        return ct.computeIfAbsent(column, c -> {
+            try {
+                return metaData.getColumnType(c);
+            } catch (SQLException e) {
+                throw new IllegalArgumentException(e);
+            }
+        });
+    }
+
+    @Override
+    public String getColumnTypeName(int column) throws SQLException {
+        throw new IllegalArgumentException();
+    }
+
+    @Override
+    public boolean isReadOnly(int column) throws SQLException {
+        throw new IllegalArgumentException();
+    }
+
+    @Override
+    public boolean isWritable(int column) throws SQLException {
+        throw new IllegalArgumentException();
+    }
+
+    @Override
+    public boolean isDefinitelyWritable(int column) throws SQLException {
+        throw new IllegalArgumentException();
+    }
+
+    @Override
+    public String getColumnClassName(int column) throws SQLException {
+        return metaData.getColumnClassName(column);
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        throw new IllegalArgumentException();
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        throw new IllegalArgumentException();
+    }
+}


### PR DESCRIPTION
This PR is part of the Nov Hackathon 2021. 

It shows one way to reduce the execution time of JdbcService.addColumn method by caching.

More details can be found here https://github.com/Talend/data-processing-runtime/pull/434