### PR TITLE
chore(TDI-47520): comment marker

### DIFF
--- a/common-stream-io/common-io/src/main/java/org/talend/components/common/stream/format/csv/CSVConfiguration.java
+++ b/common-stream-io/common-io/src/main/java/org/talend/components/common/stream/format/csv/CSVConfiguration.java
@@ -21,8 +21,15 @@ import org.talend.sdk.component.api.meta.Documentation;
 import lombok.Data;
 
 @Data
-@GridLayout({ @GridLayout.Row("lineConfiguration"), @GridLayout.Row({ "fieldSeparator" }) })
-@GridLayout(names = GridLayout.FormType.ADVANCED, value = { @GridLayout.Row({ "escape", "quotedValue" }) })
+@GridLayout({ //
+        @GridLayout.Row({ "lineConfiguration" }), //
+        @GridLayout.Row({ "fieldSeparator" })
+})
+@GridLayout(names = GridLayout.FormType.ADVANCED,
+        value = { //
+                @GridLayout.Row({ "escape", "quotedValue" }),
+                @GridLayout.Row({ "commentMarker" })
+        })
 public class CSVConfiguration implements ContentFormat {
 
     private static final long serialVersionUID = -6803208558417743486L;
@@ -40,6 +47,10 @@ public class CSVConfiguration implements ContentFormat {
     private Character escape = '\\';
 
     @Option
+    @Documentation("Comment marker.")
+    private CommentMarker commentMarker = new CommentMarker();
+
+    @Option
     @Documentation("Text enclosure character.")
     private Character quotedValue = '"';
 
@@ -48,5 +59,13 @@ public class CSVConfiguration implements ContentFormat {
             return ';';
         }
         return this.fieldSeparator.findFieldSeparator();
+    }
+
+    public Character findCommentMarker() {
+        if (commentMarker == null) {
+            return ' '; // the default value that was used
+        }
+
+        return commentMarker.findCommentMarker();
     }
 }

--- a/common-stream-io/common-io/src/main/java/org/talend/components/common/stream/format/csv/CommentMarker.java
+++ b/common-stream-io/common-io/src/main/java/org/talend/components/common/stream/format/csv/CommentMarker.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2006-2022 Talend Inc. - www.talend.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.talend.components.common.stream.format.csv;
+
+import java.io.Serializable;
+
+import org.talend.sdk.component.api.configuration.Option;
+import org.talend.sdk.component.api.configuration.condition.ActiveIf;
+import org.talend.sdk.component.api.configuration.ui.layout.GridLayout;
+import org.talend.sdk.component.api.meta.Documentation;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@GridLayout({ //
+        @GridLayout.Row({ "commentMarkerType", "commentMarker" }), //
+})
+public class CommentMarker implements Serializable {
+
+    private static final long serialVersionUID = 406534099976881354L;
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum Type {
+
+        SEMICOLON(';'),
+        COMMA(','),
+        SPACE(' '),
+        HASH('#'),
+        OTHER((char) 0);
+
+        private final char marker;
+    }
+
+    @Option
+    @Documentation("Comment marker type.")
+    private Type commentMarkerType = Type.SPACE;
+
+    @Option
+    @ActiveIf(target = "commentMarkerType", value = "OTHER")
+    @Documentation("Custom comment marker.")
+    private Character commentMarker;
+
+    public Character findCommentMarker() {
+        if (commentMarkerType != Type.OTHER) {
+            return commentMarkerType.getMarker();
+        }
+
+        return commentMarker;
+    }
+}

--- a/common-stream-io/common-io/src/main/resources/org/talend/components/common/stream/format/csv/Messages.properties
+++ b/common-stream-io/common-io/src/main/resources/org/talend/components/common/stream/format/csv/Messages.properties
@@ -1,19 +1,27 @@
-
+#
 Type.COMMA._displayName=,
 Type.SEMICOLON._displayName=;
 Type.SPACE._displayName=Space
 Type.TABULATION._displayName=Tab
+# this field in use only by comment marker
+Type.HASH._displayName=#
 Type.OTHER._displayName=Other
-
+#
 FieldSeparator.fieldSeparator._displayName=Field separator
 FieldSeparator.fieldSeparator._placeholder=Enter a field separator character
 FieldSeparator.fieldSeparatorType._displayName=Field separator type
 FieldSeparator.fieldSeparatorType._placeholder=Select a field separator type
-
-
+#
+CommentMarker.commentMarker._displayName=Comment marker
+CommentMarker.commentMarker._placeholder=
+CommentMarker.commentMarkerType._displayName=Comment marker type
+CommentMarker.commentMarkerType._placeholder=
+#
 CSVConfiguration.lineConfiguration._displayName=
 CSVConfiguration.escape._displayName=Escape character
 CSVConfiguration.escape._placeholder=Enter escape character
+CSVConfiguration.commentMarker._displayName=Comment marker
+CSVConfiguration.commentMarker._placeholder=
 CSVConfiguration.fieldSeparator._displayName=
 CSVConfiguration.quotedValue._displayName=Quote character
 CSVConfiguration.quotedValue._placeholder=Enter character for quoted value

--- a/common-stream-io/stream-csv/src/main/java/org/talend/components/common/stream/output/csv/CSVRecordWriter.java
+++ b/common-stream-io/stream-csv/src/main/java/org/talend/components/common/stream/output/csv/CSVRecordWriter.java
@@ -45,7 +45,7 @@ public class CSVRecordWriter implements RecordWriter {
 
         int nbeHeaderLine = this.config.getLineConfiguration().calcHeader();
         if (nbeHeaderLine > 0) {
-            csvFormat = csvFormat.withCommentMarker(' ');
+            csvFormat = csvFormat.withCommentMarker(config.findCommentMarker());
             if (nbeHeaderLine > 2) {
                 final String headers = String.join("", Collections.nCopies(nbeHeaderLine - 2, "\n"));
                 csvFormat = csvFormat.withHeaderComments(headers);


### PR DESCRIPTION
https://jira.talendforge.org/browse/TDI-47520

Add a new option in the common part (common-stream-io). 
it allows specific comment marker (the lines that start from this character will be recognized as comments)
The option works only on Write action when the user wants to write a header. 
For Read operation, the behavior wasn't changed. The comments are disabled. 