### PR TITLE
fix(TDI-47538): tAzureAdlsGen2Output component converts BigDecimal to String

### DIFF
--- a/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/AvroHelper.java
+++ b/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/AvroHelper.java
@@ -15,7 +15,7 @@ package org.talend.components.common.stream;
 import java.util.List;
 import org.apache.avro.Schema;
 import static java.util.stream.Collectors.toList;
-import static org.talend.components.common.stream.input.avro.Constants.AVRO_LOGICAL_TYPE;
+import static org.talend.components.common.stream.Constants.AVRO_LOGICAL_TYPE;
 
 public class AvroHelper {
 

--- a/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/Constants.java
+++ b/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/Constants.java
@@ -30,5 +30,7 @@ public class Constants {
 
     public static final String STUDIO_PRECISION = "talend.studio.precision";
 
+    public static final String BIGDECIMAL = "id_BigDecimal";
+
     public static final String STUDIO_TYPE = "talend.studio.type";
 }

--- a/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/Constants.java
+++ b/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/Constants.java
@@ -10,17 +10,25 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package org.talend.components.common.stream.input.avro;
+package org.talend.components.common.stream;
 
 public class Constants {
 
     public static final String AVRO_LOGICAL_TYPE = "logicalType";
 
-    static final String AVRO_LOGICAL_TYPE_DATE = "date";
+    public static final String AVRO_LOGICAL_TYPE_DATE = "date";
 
-    static final String AVRO_LOGICAL_TYPE_TIME_MILLIS = "time-millis";
+    public static final String AVRO_LOGICAL_TYPE_TIME_MILLIS = "time-millis";
 
-    static final String AVRO_LOGICAL_TYPE_TIMESTAMP_MILLIS = "timestamp-millis";
+    public static final String AVRO_LOGICAL_TYPE_TIMESTAMP_MILLIS = "timestamp-millis";
 
-    static final String ERROR_UNDEFINED_TYPE = "Undefined type %s.";
+    public static final String AVRO_LOGICAL_TYPE_DECIMAL = "decimal";
+
+    public static final String ERROR_UNDEFINED_TYPE = "Undefined type %s.";
+
+    public static final String STUDIO_LENGTH = "talend.studio.length";
+
+    public static final String STUDIO_PRECISION = "talend.studio.precision";
+
+    public static final String STUDIO_TYPE = "talend.studio.type";
 }

--- a/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/Constants.java
+++ b/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/Constants.java
@@ -14,6 +14,10 @@ package org.talend.components.common.stream;
 
 public class Constants {
 
+    private Constants() {
+        throw new IllegalStateException("This is a utility class and cannot be instantiated");
+    }
+
     public static final String AVRO_LOGICAL_TYPE = "logicalType";
 
     public static final String AVRO_LOGICAL_TYPE_DATE = "date";

--- a/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/input/avro/AvroToRecord.java
+++ b/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/input/avro/AvroToRecord.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 
 import org.apache.avro.generic.GenericRecord;
 import org.talend.components.common.stream.AvroHelper;
+import org.talend.components.common.stream.Constants;
 import org.talend.sdk.component.api.record.Record;
 import org.talend.sdk.component.api.record.Schema;
 import org.talend.sdk.component.api.record.Schema.Entry;

--- a/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/input/avro/AvroToRecord.java
+++ b/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/input/avro/AvroToRecord.java
@@ -144,10 +144,9 @@ public class AvroToRecord {
         case FIXED:
             objectArray = value.stream().map(obj -> {
                 if (Constants.AVRO_LOGICAL_TYPE_DECIMAL.equals(arrayInnerType.getLogicalType().getName())) {
-                    BigDecimal decimal = new BigDecimal(new BigInteger(((GenericFixed) obj).bytes()),
+                    return new BigDecimal(new BigInteger(((GenericFixed) obj).bytes()),
                             ((LogicalTypes.Decimal) AvroHelper.getUnionSchema(arrayInnerType).getLogicalType())
                                     .getScale());
-                    return decimal.toPlainString();
                 } else {
                     return ((java.nio.ByteBuffer) obj).array();
                 }

--- a/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/input/avro/AvroToRecord.java
+++ b/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/input/avro/AvroToRecord.java
@@ -14,6 +14,8 @@ package org.talend.components.common.stream.input.avro;
 
 import static java.util.stream.Collectors.toList;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -23,6 +25,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.apache.avro.LogicalTypes;
 import org.apache.avro.generic.GenericRecord;
 import org.talend.components.common.stream.AvroHelper;
 import org.talend.components.common.stream.Constants;
@@ -175,7 +178,14 @@ public class AvroToRecord {
             break;
         case BYTES:
             byte[] bytes = ((java.nio.ByteBuffer) value).array();
-            recordBuilder.withBytes(entry, bytes);
+            if (Constants.AVRO_LOGICAL_TYPE_DECIMAL.equals(logicalType)) {
+                BigDecimal decimal = new BigDecimal(new BigInteger(bytes),
+                        ((LogicalTypes.Decimal) AvroHelper.getUnionSchema(field.schema()).getLogicalType())
+                                .getScale());
+                recordBuilder.withString(entry, decimal.toPlainString());
+            } else {
+                recordBuilder.withBytes(entry, bytes);
+            }
             break;
         case INT:
             int ivalue = (Integer) value;

--- a/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/input/avro/AvroToSchema.java
+++ b/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/input/avro/AvroToSchema.java
@@ -13,6 +13,7 @@
 package org.talend.components.common.stream.input.avro;
 
 import org.talend.components.common.stream.AvroHelper;
+import org.talend.components.common.stream.Constants;
 import org.talend.sdk.component.api.record.Schema;
 import org.talend.sdk.component.api.service.record.RecordBuilderFactory;
 

--- a/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/input/avro/AvroToSchema.java
+++ b/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/input/avro/AvroToSchema.java
@@ -12,7 +12,8 @@
  */
 package org.talend.components.common.stream.input.avro;
 
-import org.apache.avro.LogicalType;
+import static org.talend.components.common.stream.Constants.BIGDECIMAL;
+
 import org.apache.avro.LogicalTypes;
 import org.talend.components.common.stream.AvroHelper;
 import org.talend.components.common.stream.Constants;
@@ -20,8 +21,6 @@ import org.talend.sdk.component.api.record.Schema;
 import org.talend.sdk.component.api.service.record.RecordBuilderFactory;
 
 import lombok.RequiredArgsConstructor;
-
-import static org.talend.components.common.stream.Constants.BIGDECIMAL;
 
 @RequiredArgsConstructor
 public class AvroToSchema {

--- a/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/input/avro/AvroToSchema.java
+++ b/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/input/avro/AvroToSchema.java
@@ -75,6 +75,7 @@ public class AvroToSchema {
             builder.withType(translateToRecordType(type));
             break;
         case BYTES:
+        case FIXED:
             if (Constants.AVRO_LOGICAL_TYPE_DECIMAL.equals(logicalType)) {
                 LogicalTypes.Decimal decimalType =
                         ((LogicalTypes.Decimal) AvroHelper.getUnionSchema(field.schema()).getLogicalType());
@@ -126,6 +127,7 @@ public class AvroToSchema {
         case STRING:
             return Schema.Type.STRING;
         case BYTES:
+        case FIXED:
             return Schema.Type.BYTES;
         case INT:
             return Schema.Type.INT;

--- a/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/output/avro/RecordToAvro.java
+++ b/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/output/avro/RecordToAvro.java
@@ -34,8 +34,6 @@ import org.talend.sdk.component.api.record.Record;
 import org.talend.sdk.component.api.record.Schema;
 import org.talend.sdk.component.api.record.Schema.Entry;
 
-import static org.apache.avro.Schema.Type.FIXED;
-
 public class RecordToAvro implements RecordConverter<GenericRecord, org.apache.avro.Schema> {
 
     private static final String ERROR_UNDEFINED_TYPE = "Undefined type %s.";

--- a/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/output/avro/SchemaToAvro.java
+++ b/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/output/avro/SchemaToAvro.java
@@ -48,7 +48,7 @@ public class SchemaToAvro {
             org.apache.avro.Schema builder = null;
             String studioType = e.getProp(STUDIO_TYPE);
             if (studioType != null && BIGDECIMAL.equals(studioType)) {
-                builder = org.apache.avro.Schema.create(org.apache.avro.Schema.Type.BYTES);
+                builder = org.apache.avro.Schema.createFixed(name, null, null, 16);
                 String lengthStr = e.getProp(STUDIO_LENGTH);
                 int length = 0;
                 if (lengthStr != null && !lengthStr.isEmpty()) {

--- a/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/output/avro/SchemaToAvro.java
+++ b/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/output/avro/SchemaToAvro.java
@@ -89,10 +89,7 @@ public class SchemaToAvro {
     }
 
     private boolean isDecimalType(Map<String, String> props) {
-        if (props != null && props.get(STUDIO_TYPE) != null && BIGDECIMAL.equals(props.get(STUDIO_TYPE))) {
-            return true;
-        }
-        return false;
+        return props != null && props.get(STUDIO_TYPE) != null && BIGDECIMAL.equals(props.get(STUDIO_TYPE));
     }
 
     private org.apache.avro.Schema extractSchema(

--- a/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/output/avro/SchemaToAvro.java
+++ b/common-stream-io/stream-avro/src/main/java/org/talend/components/common/stream/output/avro/SchemaToAvro.java
@@ -28,8 +28,6 @@ public class SchemaToAvro {
 
     private static final String RECORD_NAME = "talend_";
 
-    private static final String BIGDECIMAL = "id_BigDecimal";
-
     private final String currentRecordNamespace;
 
     public SchemaToAvro(String currentRecordNamespace) {
@@ -49,19 +47,19 @@ public class SchemaToAvro {
 
             org.apache.avro.Schema builder = null;
             String studioType = e.getProp(STUDIO_TYPE);
-            if (studioType != null && !studioType.isEmpty() && studioType.equals(BIGDECIMAL)) {
+            if (studioType != null && BIGDECIMAL.equals(studioType)) {
                 builder = org.apache.avro.Schema.create(org.apache.avro.Schema.Type.BYTES);
-                String precisionStr = e.getProp(STUDIO_PRECISION);
-                int precision = 0;
-                if (precisionStr != null && !precisionStr.isEmpty()) {
-                    precision = Integer.parseInt(precisionStr);
-                }
                 String lengthStr = e.getProp(STUDIO_LENGTH);
+                int length = 0;
                 if (lengthStr != null && !lengthStr.isEmpty()) {
-                    int length = Integer.parseInt(lengthStr);
-                    LogicalTypes.decimal(length, precision).addToSchema(builder);
+                    length = Integer.parseInt(lengthStr);
+                }
+                String precisionStr = e.getProp(STUDIO_PRECISION);
+                if (precisionStr != null && !precisionStr.isEmpty()) {
+                    int scale = Integer.parseInt(precisionStr);
+                    LogicalTypes.decimal(length, scale).addToSchema(builder);
                 } else {
-                    LogicalTypes.decimal(precision).addToSchema(builder);
+                    LogicalTypes.decimal(length).addToSchema(builder);
                 }
             } else {
                 builder = this.extractSchema(name, e.getType(), e.getElementSchema());

--- a/common-stream-io/stream-avro/src/test/java/org/talend/components/common/stream/input/avro/AvroToRecordTest.java
+++ b/common-stream-io/stream-avro/src/test/java/org/talend/components/common/stream/input/avro/AvroToRecordTest.java
@@ -61,12 +61,8 @@ class AvroToRecordTest {
     }
 
     private org.apache.avro.Schema getArrayRecord() {
-        return SchemaBuilder.record("inner")
-                .fields()
-                .name("f1")
-                .type()
-                .stringType()
-                .noDefault()
+        return SchemaBuilder.record("inner").fields()
+                .name("f1").type().stringType().noDefault()
                 .endRecord();
     }
 
@@ -167,14 +163,9 @@ class AvroToRecordTest {
                         .addToSchema(org.apache.avro.Schema.createFixed("decimal", null, null, 16)))
                 .noDefault() //
                 .name("decimalArray")
-                .type(org.apache.avro.SchemaBuilder.array()
-                        .items(SchemaBuilder.unionOf()
-                                .nullType()
-                                .and()
-                                .type(LogicalTypes.decimal(10, 3)
-                                        .addToSchema(
-                                                org.apache.avro.Schema.createFixed("decimalElement", null, null, 16)))
-                                .endUnion()))
+                .type(org.apache.avro.Schema.createArray(LogicalTypes.decimal(10, 3)
+                        .addToSchema(
+                                org.apache.avro.Schema.createFixed(null, null, null, 16))))
                 .noDefault()
                 .endRecord();
 
@@ -196,10 +187,10 @@ class AvroToRecordTest {
         Record record = toRecord.toRecord(decimalRecord);
         assertNotNull(record);
         assertEquals("123.45", record.getString("decimal"));
-        final Collection<String> records = record.getArray(String.class, "decimalArray");
+        final Collection<BigDecimal> records = record.getArray(BigDecimal.class, "decimalArray");
         assertEquals(2, records.size());
-        assertTrue(records.containsAll(Arrays.asList("1234.467","12345.678")));
-
+        assertEquals(Arrays.asList(new BigDecimal("1234.467"), new BigDecimal("12345.678")), records);
+        System.out.println(schema);
     }
 
     @ParameterizedTest
@@ -277,7 +268,7 @@ class AvroToRecordTest {
         Assertions.assertTrue(this.equalsSchema(avroRecord.getSchema(), tckRecord.getSchema()));
         Assertions.assertEquals(tckRecord.getSchema(), tckRecord2.getSchema());
     }
-    
+
     private byte[] decimalToBytes(BigDecimal decimal) {
         byte fillByte = (byte) (decimal.signum() < 0 ? 0xFF : 0x00);
         byte[] unscaled = decimal.unscaledValue().toByteArray();

--- a/common-stream-io/stream-avro/src/test/java/org/talend/components/common/stream/input/avro/AvroToRecordTest.java
+++ b/common-stream-io/stream-avro/src/test/java/org/talend/components/common/stream/input/avro/AvroToRecordTest.java
@@ -190,7 +190,6 @@ class AvroToRecordTest {
         final Collection<BigDecimal> records = record.getArray(BigDecimal.class, "decimalArray");
         assertEquals(2, records.size());
         assertEquals(Arrays.asList(new BigDecimal("1234.467"), new BigDecimal("12345.678")), records);
-        System.out.println(schema);
     }
 
     @ParameterizedTest

--- a/common-stream-io/stream-avro/src/test/java/org/talend/components/common/stream/output/avro/RecordToAvroTest.java
+++ b/common-stream-io/stream-avro/src/test/java/org/talend/components/common/stream/output/avro/RecordToAvroTest.java
@@ -184,9 +184,12 @@ class RecordToAvroTest {
         final GenericRecord record = converter.fromRecord(decimalRecord);
         assertNotNull(record);
         assertEquals("DecimalR", record.get("name"));
-        GenericData.Fixed value = (GenericData.Fixed) record.get("BIG_DECIMALS");
+        GenericData.Fixed value = (GenericData.Fixed) record.get("big_decimal");
         BigDecimal bd = new BigDecimal(new BigInteger(value.bytes()), 5);
         assertEquals(new BigDecimal("12345.67890"), bd);
+
+        assertEquals(Arrays.asList(new BigDecimal("12.34567"), new BigDecimal("21.76543")),
+                decimalRecord.getArray(BigDecimal.class, "decimal_array"));
     }
 
     @Test
@@ -368,16 +371,28 @@ class RecordToAvroTest {
                 .withDateTime("now", now) //
                 .withArray(ea, Arrays.asList("ary1", "ary2", "ary3"))
                 .build();
+        Entry decimalArray = factory
+                .newEntryBuilder()
+                .withName("decimal_array")
+                .withType(Type.ARRAY)
+                .withElementSchema(factory.newSchemaBuilder(Type.ARRAY)
+                        .withType(Type.STRING)
+                        .withProp(STUDIO_TYPE, "id_BigDecimal")
+                        .withProp(STUDIO_LENGTH, "10")
+                        .withProp(STUDIO_PRECISION, "5")
+                        .build())
+                .build();
         decimalRecord = factory
                 .newRecordBuilder() //
                 .withString("name", "DecimalR") //
                 .withString(factory.newEntryBuilder()
-                        .withName("BIG_DECIMALS")
+                        .withName("big_decimal")
                         .withType(Type.STRING)
                         .withProp(STUDIO_TYPE, "id_BigDecimal")
                         .withProp(STUDIO_LENGTH, "10")
                         .withProp(STUDIO_PRECISION, "5")
                         .build(), "12345.67890")
+                .withArray(decimalArray, Arrays.asList(new BigDecimal("12.34567"), new BigDecimal("21.76543")))
                 .build();
     }
 

--- a/common-stream-io/stream-avro/src/test/java/org/talend/components/common/stream/output/avro/RecordToAvroTest.java
+++ b/common-stream-io/stream-avro/src/test/java/org/talend/components/common/stream/output/avro/RecordToAvroTest.java
@@ -184,8 +184,8 @@ class RecordToAvroTest {
         final GenericRecord record = converter.fromRecord(decimalRecord);
         assertNotNull(record);
         assertEquals("DecimalR", record.get("name"));
-        ByteBuffer byteBuffer = (ByteBuffer) record.get("BIG_DECIMALS");
-        BigDecimal bd = new BigDecimal(new BigInteger(byteBuffer.array()), 5);
+        GenericData.Fixed value = (GenericData.Fixed) record.get("BIG_DECIMALS");
+        BigDecimal bd = new BigDecimal(new BigInteger(value.bytes()), 5);
         assertEquals(new BigDecimal("12345.67890"), bd);
     }
 

--- a/common-stream-io/stream-avro/src/test/java/org/talend/components/common/stream/output/avro/RecordToAvroTest.java
+++ b/common-stream-io/stream-avro/src/test/java/org/talend/components/common/stream/output/avro/RecordToAvroTest.java
@@ -14,7 +14,11 @@ package org.talend.components.common.stream.output.avro;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.talend.components.common.stream.Constants.*;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -46,6 +50,8 @@ class RecordToAvroTest {
     protected Record versatileRecord;
 
     protected Record complexRecord;
+
+    private Record decimalRecord;
 
     private RecordBuilderFactory factory = new RecordBuilderFactoryImpl("test");
 
@@ -170,6 +176,17 @@ class RecordToAvroTest {
                 record.get("datetime"));
         assertEquals(20.5f, record.get("float"));
         assertEquals(20.5, record.get("double"));
+    }
+
+    @Test
+    void testFromDecimalRecord() {
+        final RecordToAvro converter = new RecordToAvro("test");
+        final GenericRecord record = converter.fromRecord(decimalRecord);
+        assertNotNull(record);
+        assertEquals("DecimalR", record.get("name"));
+        ByteBuffer byteBuffer = (ByteBuffer) record.get("BIG_DECIMALS");
+        BigDecimal bd = new BigDecimal(new BigInteger(byteBuffer.array()), 5);
+        assertEquals(new BigDecimal("12345.67890"), bd);
     }
 
     @Test
@@ -350,6 +367,17 @@ class RecordToAvroTest {
                 .withRecord(er, versatileRecord) //
                 .withDateTime("now", now) //
                 .withArray(ea, Arrays.asList("ary1", "ary2", "ary3"))
+                .build();
+        decimalRecord = factory
+                .newRecordBuilder() //
+                .withString("name", "DecimalR") //
+                .withString(factory.newEntryBuilder()
+                        .withName("BIG_DECIMALS")
+                        .withType(Type.STRING)
+                        .withProp(STUDIO_TYPE, "id_BigDecimal")
+                        .withProp(STUDIO_LENGTH, "10")
+                        .withProp(STUDIO_PRECISION, "5")
+                        .build(), "12345.67890")
                 .build();
     }
 


### PR DESCRIPTION
for: https://jira.talendforge.org/browse/TDI-47538

tAzureAdlsGen2Output write and read bigdecimal type in parquet type