### PR TITLE
chore(TDI-49778): Bump component-runtime to 1.56.1 in connectors

### DIFF
--- a/azure/azure-dls-gen2/pom.xml
+++ b/azure/azure-dls-gen2/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>azure</artifactId>
-    <version>1.45.0-SNAPSHOT</version>
+    <version>1.45.0</version>
   </parent>
 
   <artifactId>azure-dls-gen2</artifactId>

--- a/azure/azure-dls-gen2/pom.xml
+++ b/azure/azure-dls-gen2/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>azure</artifactId>
-    <version>1.45.0</version>
+    <version>1.45.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>azure-dls-gen2</artifactId>

--- a/azure/azureblob/pom.xml
+++ b/azure/azureblob/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>azure</artifactId>
-        <version>1.45.0-SNAPSHOT</version>
+        <version>1.45.0</version>
     </parent>
 
     <artifactId>azureblob</artifactId>

--- a/azure/azureblob/pom.xml
+++ b/azure/azureblob/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>azure</artifactId>
-        <version>1.45.0</version>
+        <version>1.45.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>azureblob</artifactId>

--- a/azure/azurecommon/pom.xml
+++ b/azure/azurecommon/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>azure</artifactId>
-    <version>1.45.0</version>
+    <version>1.45.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>azurecommon</artifactId>

--- a/azure/azurecommon/pom.xml
+++ b/azure/azurecommon/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>azure</artifactId>
-    <version>1.45.0-SNAPSHOT</version>
+    <version>1.45.0</version>
   </parent>
 
   <artifactId>azurecommon</artifactId>

--- a/azure/pom.xml
+++ b/azure/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>connectors-se</artifactId>
-    <version>1.45.0</version>
+    <version>1.45.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>azure</artifactId>

--- a/azure/pom.xml
+++ b/azure/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>connectors-se</artifactId>
-    <version>1.45.0-SNAPSHOT</version>
+    <version>1.45.0</version>
   </parent>
 
   <artifactId>azure</artifactId>

--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>connectors-se</artifactId>
-        <version>1.45.0-SNAPSHOT</version>
+        <version>1.45.0</version>
     </parent>
 
     <artifactId>bigquery</artifactId>

--- a/bigquery/pom.xml
+++ b/bigquery/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>connectors-se</artifactId>
-        <version>1.45.0</version>
+        <version>1.45.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>bigquery</artifactId>

--- a/common-stream-io/common-io/pom.xml
+++ b/common-stream-io/common-io/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>common-stream-io</artifactId>
-        <version>1.45.0</version>
+        <version>1.45.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>common-io</artifactId>

--- a/common-stream-io/common-io/pom.xml
+++ b/common-stream-io/common-io/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>common-stream-io</artifactId>
-        <version>1.45.0-SNAPSHOT</version>
+        <version>1.45.0</version>
     </parent>
 
     <artifactId>common-io</artifactId>

--- a/common-stream-io/pom.xml
+++ b/common-stream-io/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>connectors-se</artifactId>
-        <version>1.45.0</version>
+        <version>1.45.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>common-stream-io</artifactId>

--- a/common-stream-io/pom.xml
+++ b/common-stream-io/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>connectors-se</artifactId>
-        <version>1.45.0-SNAPSHOT</version>
+        <version>1.45.0</version>
     </parent>
 
     <artifactId>common-stream-io</artifactId>

--- a/common-stream-io/stream-api/pom.xml
+++ b/common-stream-io/stream-api/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>common-stream-io</artifactId>
-    <version>1.45.0</version>
+    <version>1.45.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>stream-api</artifactId>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>org.talend.components</groupId>
       <artifactId>common-io</artifactId>
-      <version>1.45.0</version>
+      <version>1.45.1-SNAPSHOT</version>
     </dependency>
   </dependencies>
 </project>

--- a/common-stream-io/stream-api/pom.xml
+++ b/common-stream-io/stream-api/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>common-stream-io</artifactId>
-    <version>1.45.0-SNAPSHOT</version>
+    <version>1.45.0</version>
   </parent>
 
   <artifactId>stream-api</artifactId>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>org.talend.components</groupId>
       <artifactId>common-io</artifactId>
-      <version>1.45.0-SNAPSHOT</version>
+      <version>1.45.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/common-stream-io/stream-avro/pom.xml
+++ b/common-stream-io/stream-avro/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>common-stream-io</artifactId>
-        <version>1.45.0-SNAPSHOT</version>
+        <version>1.45.0</version>
     </parent>
 
     <artifactId>stream-avro</artifactId>
@@ -30,14 +30,14 @@
         <dependency>
             <groupId>org.talend.components</groupId>
             <artifactId>stream-api</artifactId>
-            <version>1.45.0-SNAPSHOT</version>
+            <version>1.45.0</version>
         </dependency>
 
         <!-- common -->
         <dependency>
             <groupId>org.talend.components</groupId>
             <artifactId>common</artifactId>
-            <version>1.45.0-SNAPSHOT</version>
+            <version>1.45.0</version>
         </dependency>
 
         <dependency>

--- a/common-stream-io/stream-avro/pom.xml
+++ b/common-stream-io/stream-avro/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>common-stream-io</artifactId>
-        <version>1.45.0</version>
+        <version>1.45.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>stream-avro</artifactId>
@@ -30,14 +30,14 @@
         <dependency>
             <groupId>org.talend.components</groupId>
             <artifactId>stream-api</artifactId>
-            <version>1.45.0</version>
+            <version>1.45.1-SNAPSHOT</version>
         </dependency>
 
         <!-- common -->
         <dependency>
             <groupId>org.talend.components</groupId>
             <artifactId>common</artifactId>
-            <version>1.45.0</version>
+            <version>1.45.1-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/common-stream-io/stream-csv/pom.xml
+++ b/common-stream-io/stream-csv/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>common-stream-io</artifactId>
-    <version>1.45.0</version>
+    <version>1.45.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>stream-csv</artifactId>
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>org.talend.components</groupId>
       <artifactId>stream-line</artifactId>
-      <version>1.45.0</version>
+      <version>1.45.1-SNAPSHOT</version>
     </dependency>
 
     <!-- CSV -->

--- a/common-stream-io/stream-csv/pom.xml
+++ b/common-stream-io/stream-csv/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>common-stream-io</artifactId>
-    <version>1.45.0-SNAPSHOT</version>
+    <version>1.45.0</version>
   </parent>
 
   <artifactId>stream-csv</artifactId>
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>org.talend.components</groupId>
       <artifactId>stream-line</artifactId>
-      <version>1.45.0-SNAPSHOT</version>
+      <version>1.45.0</version>
     </dependency>
 
     <!-- CSV -->

--- a/common-stream-io/stream-excel/pom.xml
+++ b/common-stream-io/stream-excel/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>common-stream-io</artifactId>
-        <version>1.45.0-SNAPSHOT</version>
+        <version>1.45.0</version>
     </parent>
 
     <artifactId>stream-excel</artifactId>
@@ -21,12 +21,12 @@
         <dependency>
             <groupId>org.talend.components</groupId>
             <artifactId>stream-api</artifactId>
-            <version>1.45.0-SNAPSHOT</version>
+            <version>1.45.0</version>
         </dependency>
         <dependency>
             <groupId>org.talend.components</groupId>
             <artifactId>common</artifactId>
-            <version>1.45.0-SNAPSHOT</version>
+            <version>1.45.0</version>
         </dependency>
 
         <!-- Excel -->

--- a/common-stream-io/stream-excel/pom.xml
+++ b/common-stream-io/stream-excel/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>common-stream-io</artifactId>
-        <version>1.45.0</version>
+        <version>1.45.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>stream-excel</artifactId>
@@ -21,12 +21,12 @@
         <dependency>
             <groupId>org.talend.components</groupId>
             <artifactId>stream-api</artifactId>
-            <version>1.45.0</version>
+            <version>1.45.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.talend.components</groupId>
             <artifactId>common</artifactId>
-            <version>1.45.0</version>
+            <version>1.45.1-SNAPSHOT</version>
         </dependency>
 
         <!-- Excel -->

--- a/common-stream-io/stream-fixed/pom.xml
+++ b/common-stream-io/stream-fixed/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>common-stream-io</artifactId>
-    <version>1.45.0</version>
+    <version>1.45.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>stream-fixed</artifactId>
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>org.talend.components</groupId>
       <artifactId>stream-line</artifactId>
-      <version>1.45.0</version>
+      <version>1.45.1-SNAPSHOT</version>
     </dependency>
   </dependencies>
 </project>

--- a/common-stream-io/stream-fixed/pom.xml
+++ b/common-stream-io/stream-fixed/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>common-stream-io</artifactId>
-    <version>1.45.0-SNAPSHOT</version>
+    <version>1.45.0</version>
   </parent>
 
   <artifactId>stream-fixed</artifactId>
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>org.talend.components</groupId>
       <artifactId>stream-line</artifactId>
-      <version>1.45.0-SNAPSHOT</version>
+      <version>1.45.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/common-stream-io/stream-json/pom.xml
+++ b/common-stream-io/stream-json/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>common-stream-io</artifactId>
-    <version>1.45.0</version>
+    <version>1.45.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>stream-json</artifactId>
@@ -44,12 +44,12 @@
     <dependency>
       <groupId>org.talend.components</groupId>
       <artifactId>common</artifactId>
-      <version>1.45.0</version>
+      <version>1.45.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.talend.components</groupId>
       <artifactId>stream-api</artifactId>
-      <version>1.45.0</version>
+      <version>1.45.1-SNAPSHOT</version>
     </dependency>
     <!-- Testing -->
     <dependency>

--- a/common-stream-io/stream-json/pom.xml
+++ b/common-stream-io/stream-json/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>common-stream-io</artifactId>
-    <version>1.45.0-SNAPSHOT</version>
+    <version>1.45.0</version>
   </parent>
 
   <artifactId>stream-json</artifactId>
@@ -44,12 +44,12 @@
     <dependency>
       <groupId>org.talend.components</groupId>
       <artifactId>common</artifactId>
-      <version>1.45.0-SNAPSHOT</version>
+      <version>1.45.0</version>
     </dependency>
     <dependency>
       <groupId>org.talend.components</groupId>
       <artifactId>stream-api</artifactId>
-      <version>1.45.0-SNAPSHOT</version>
+      <version>1.45.0</version>
     </dependency>
     <!-- Testing -->
     <dependency>

--- a/common-stream-io/stream-line/pom.xml
+++ b/common-stream-io/stream-line/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>common-stream-io</artifactId>
-    <version>1.45.0-SNAPSHOT</version>
+    <version>1.45.0</version>
   </parent>
 
   <artifactId>stream-line</artifactId>
@@ -29,13 +29,13 @@
     <dependency>
       <groupId>org.talend.components</groupId>
       <artifactId>stream-api</artifactId>
-      <version>1.45.0-SNAPSHOT</version>
+      <version>1.45.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.talend.components</groupId>
       <artifactId>common</artifactId>
-      <version>1.45.0-SNAPSHOT</version>
+      <version>1.45.0</version>
     </dependency>
     <dependency>
       <groupId>org.talend.components</groupId>

--- a/common-stream-io/stream-line/pom.xml
+++ b/common-stream-io/stream-line/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>common-stream-io</artifactId>
-    <version>1.45.0</version>
+    <version>1.45.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>stream-line</artifactId>
@@ -29,13 +29,13 @@
     <dependency>
       <groupId>org.talend.components</groupId>
       <artifactId>stream-api</artifactId>
-      <version>1.45.0</version>
+      <version>1.45.1-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.talend.components</groupId>
       <artifactId>common</artifactId>
-      <version>1.45.0</version>
+      <version>1.45.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.talend.components</groupId>

--- a/common-stream-io/stream-rawtext/pom.xml
+++ b/common-stream-io/stream-rawtext/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>common-stream-io</artifactId>
-        <version>1.45.0</version>
+        <version>1.45.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>stream-rawtext</artifactId>
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>org.talend.components</groupId>
             <artifactId>stream-api</artifactId>
-            <version>1.45.0</version>
+            <version>1.45.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/common-stream-io/stream-rawtext/pom.xml
+++ b/common-stream-io/stream-rawtext/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>common-stream-io</artifactId>
-        <version>1.45.0-SNAPSHOT</version>
+        <version>1.45.0</version>
     </parent>
 
     <artifactId>stream-rawtext</artifactId>
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>org.talend.components</groupId>
             <artifactId>stream-api</artifactId>
-            <version>1.45.0-SNAPSHOT</version>
+            <version>1.45.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/common-test/pom.xml
+++ b/common-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>connectors-se</artifactId>
-        <version>1.45.0-SNAPSHOT</version>
+        <version>1.45.0</version>
     </parent>
 
     <artifactId>common-test</artifactId>

--- a/common-test/pom.xml
+++ b/common-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>connectors-se</artifactId>
-        <version>1.45.0</version>
+        <version>1.45.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>common-test</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>connectors-se</artifactId>
-        <version>1.45.0-SNAPSHOT</version>
+        <version>1.45.0</version>
     </parent>
 
     <artifactId>common</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>connectors-se</artifactId>
-        <version>1.45.0</version>
+        <version>1.45.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>common</artifactId>

--- a/connectors-test-bom/pom.xml
+++ b/connectors-test-bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>connectors-se</artifactId>
-        <version>1.45.0-SNAPSHOT</version>
+        <version>1.45.0</version>
     </parent>
 
     <artifactId>connectors-test-bom</artifactId>

--- a/connectors-test-bom/pom.xml
+++ b/connectors-test-bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>connectors-se</artifactId>
-        <version>1.45.0</version>
+        <version>1.45.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>connectors-test-bom</artifactId>

--- a/cosmosDB/pom.xml
+++ b/cosmosDB/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>connectors-se</artifactId>
-    <version>1.45.0-SNAPSHOT</version>
+    <version>1.45.0</version>
   </parent>
 
   <artifactId>cosmosDB</artifactId>

--- a/cosmosDB/pom.xml
+++ b/cosmosDB/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>connectors-se</artifactId>
-    <version>1.45.0</version>
+    <version>1.45.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>cosmosDB</artifactId>

--- a/couchbase/pom.xml
+++ b/couchbase/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>connectors-se</artifactId>
-    <version>1.45.0</version>
+    <version>1.45.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>couchbase</artifactId>

--- a/couchbase/pom.xml
+++ b/couchbase/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>connectors-se</artifactId>
-    <version>1.45.0-SNAPSHOT</version>
+    <version>1.45.0</version>
   </parent>
 
   <artifactId>couchbase</artifactId>

--- a/dynamics-crm/pom.xml
+++ b/dynamics-crm/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>connectors-se</artifactId>
-        <version>1.45.0</version>
+        <version>1.45.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>dynamics-crm</artifactId>

--- a/dynamics-crm/pom.xml
+++ b/dynamics-crm/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>connectors-se</artifactId>
-        <version>1.45.0-SNAPSHOT</version>
+        <version>1.45.0</version>
     </parent>
 
     <artifactId>dynamics-crm</artifactId>

--- a/extensions/polling/pom.xml
+++ b/extensions/polling/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components.extension</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.45.0</version>
+        <version>1.45.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>polling</artifactId>

--- a/extensions/polling/pom.xml
+++ b/extensions/polling/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components.extension</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.45.0-SNAPSHOT</version>
+        <version>1.45.0</version>
     </parent>
 
     <artifactId>polling</artifactId>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>connectors-se</artifactId>
-    <version>1.45.0</version>
+    <version>1.45.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.talend.components.extension</groupId>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>connectors-se</artifactId>
-    <version>1.45.0-SNAPSHOT</version>
+    <version>1.45.0</version>
   </parent>
 
   <groupId>org.talend.components.extension</groupId>

--- a/extensions/register-extension/pom.xml
+++ b/extensions/register-extension/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components.extension</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.45.0-SNAPSHOT</version>
+        <version>1.45.0</version>
     </parent>
 
     <artifactId>register-extension</artifactId>

--- a/extensions/register-extension/pom.xml
+++ b/extensions/register-extension/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components.extension</groupId>
         <artifactId>extensions</artifactId>
-        <version>1.45.0</version>
+        <version>1.45.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>register-extension</artifactId>

--- a/google-storage/pom.xml
+++ b/google-storage/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>connectors-se</artifactId>
-        <version>1.45.0-SNAPSHOT</version>
+        <version>1.45.0</version>
     </parent>
 
     <artifactId>google-storage</artifactId>

--- a/google-storage/pom.xml
+++ b/google-storage/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>connectors-se</artifactId>
-        <version>1.45.0</version>
+        <version>1.45.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>google-storage</artifactId>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>connectors-se</artifactId>
-        <version>1.45.0</version>
+        <version>1.45.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jdbc</artifactId>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>connectors-se</artifactId>
-        <version>1.45.0-SNAPSHOT</version>
+        <version>1.45.0</version>
     </parent>
 
     <artifactId>jdbc</artifactId>

--- a/marketo/pom.xml
+++ b/marketo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>connectors-se</artifactId>
-        <version>1.45.0</version>
+        <version>1.45.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>marketo</artifactId>

--- a/marketo/pom.xml
+++ b/marketo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>connectors-se</artifactId>
-        <version>1.45.0-SNAPSHOT</version>
+        <version>1.45.0</version>
     </parent>
 
     <artifactId>marketo</artifactId>

--- a/migration-tester/pom.xml
+++ b/migration-tester/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>connectors-se</artifactId>
-    <version>1.45.0-SNAPSHOT</version>
+    <version>1.45.0</version>
   </parent>
 
   <artifactId>migration-tester</artifactId>

--- a/migration-tester/pom.xml
+++ b/migration-tester/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>connectors-se</artifactId>
-    <version>1.45.0</version>
+    <version>1.45.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>migration-tester</artifactId>

--- a/mongodb/mongodb-common/pom.xml
+++ b/mongodb/mongodb-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>mongodb-parent</artifactId>
-        <version>1.45.0</version>
+        <version>1.45.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mongodb-common</artifactId>

--- a/mongodb/mongodb-common/pom.xml
+++ b/mongodb/mongodb-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>mongodb-parent</artifactId>
-        <version>1.45.0-SNAPSHOT</version>
+        <version>1.45.0</version>
     </parent>
 
     <artifactId>mongodb-common</artifactId>

--- a/mongodb/mongodb/pom.xml
+++ b/mongodb/mongodb/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>mongodb-parent</artifactId>
-    <version>1.45.0-SNAPSHOT</version>
+    <version>1.45.0</version>
   </parent>
 
   <artifactId>mongodb</artifactId>

--- a/mongodb/mongodb/pom.xml
+++ b/mongodb/mongodb/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>mongodb-parent</artifactId>
-    <version>1.45.0</version>
+    <version>1.45.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>mongodb</artifactId>

--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>connectors-se</artifactId>
-        <version>1.45.0</version>
+        <version>1.45.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mongodb-parent</artifactId>

--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.components</groupId>
         <artifactId>connectors-se</artifactId>
-        <version>1.45.0-SNAPSHOT</version>
+        <version>1.45.0</version>
     </parent>
 
     <artifactId>mongodb-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>connectors-se</artifactId>
-    <version>1.45.0-SNAPSHOT</version>
+    <version>1.45.0</version>
     <packaging>pom</packaging>
 
     <name>Connectors SE</name>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>org.talend.components</groupId>
     <artifactId>connectors-se</artifactId>
-    <version>1.45.0</version>
+    <version>1.45.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Connectors SE</name>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <maven.build.timestamp.format>yyyy</maven.build.timestamp.format>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <component-runtime.version>1.56.0</component-runtime.version>
+        <component-runtime.version>1.56.1</component-runtime.version>
 
         <slf4j.version>1.7.36</slf4j.version>
         <log4j-api.version>2.20.0</log4j-api.version>

--- a/salesforce/pom.xml
+++ b/salesforce/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>connectors-se</artifactId>
-    <version>1.45.0</version>
+    <version>1.45.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>salesforce</artifactId>

--- a/salesforce/pom.xml
+++ b/salesforce/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.talend.components</groupId>
     <artifactId>connectors-se</artifactId>
-    <version>1.45.0-SNAPSHOT</version>
+    <version>1.45.0</version>
   </parent>
 
   <artifactId>salesforce</artifactId>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TDI-49778