### PR TITLE
fix(TDI-50450): CVE upgrade snappy-java to 1.1.10.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
 
         <bouncycastle.version>1.73</bouncycastle.version>
         <pgpainless.version>1.5.1</pgpainless.version>
-        <snappy.version>1.1.10.1</snappy.version>
+        <snappy.version>1.1.10.5</snappy.version>
 
         <!-- code quality enforcer default values.
              run build w/ -Pcode-quality to have a full validation -->


### PR DESCRIPTION
https://jira.talendforge.org/browse/TDI-50450